### PR TITLE
Added more Ad Networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ captures/
 .idea/dictionaries
 .idea/libraries
 .idea/caches
+.idea/
 
 # Keystore files
 # Uncomment the following line if you do not want to check your keystore files in.
@@ -63,3 +64,6 @@ fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
 fastlane/readme.md
+
+# DS_Store
+.DS_Store

--- a/library/src/main/java/com/michaelflisar/gdprdialog/GDPRDefinitions.java
+++ b/library/src/main/java/com/michaelflisar/gdprdialog/GDPRDefinitions.java
@@ -5,6 +5,14 @@ import android.content.Context;
 public class GDPRDefinitions {
 
     public static GDPRNetwork ADMOB = null;
+    public static GDPRNetwork AERSERV = null;
+    public static GDPRNetwork INMOBI = null;
+    public static GDPRNetwork MOPUB = null;
+    public static GDPRNetwork VUNGLE = null;
+    public static GDPRNetwork ADCOLONY = null;
+    public static GDPRNetwork UNITY = null;
+    public static GDPRNetwork APPLOVIN = null;
+
     public static GDPRNetwork FIREBASE_DATABASE = null;
     public static GDPRNetwork FIREBASE_CRASH = null;
     public static GDPRNetwork FIREBASE_ANALYTICS = null;
@@ -12,6 +20,15 @@ public class GDPRDefinitions {
     public static void init(Context context) {
         // Init networks
         ADMOB = new GDPRNetwork(context, R.string.gdpr_network_admob, R.string.gdpr_network_admob_link, R.string.gdpr_type_ads, true, true);
+        AERSERV = new GDPRNetwork(context, R.string.gdpr_network_aerserv, R.string.gdpr_network_aerserv_link, R.string.gdpr_type_ads, true, true);
+        INMOBI = new GDPRNetwork(context, R.string.gdpr_network_inmobi, R.string.gdpr_network_inmobi_link, R.string.gdpr_type_ads, true, true);
+        MOPUB = new GDPRNetwork(context, R.string.gdpr_network_mopub, R.string.gdpr_network_mopub_link, R.string.gdpr_type_ads, true, true);
+        VUNGLE = new GDPRNetwork(context, R.string.gdpr_network_vungle, R.string.gdpr_network_vungle_link, R.string.gdpr_type_ads, true, true);
+        ADCOLONY = new GDPRNetwork(context, R.string.gdpr_network_adcolony, R.string.gdpr_network_adcolony_link, R.string.gdpr_type_ads, true, true);
+        UNITY = new GDPRNetwork(context, R.string.gdpr_network_unity, R.string.gdpr_network_unity_link, R.string.gdpr_type_ads, true, true);
+        APPLOVIN = new GDPRNetwork(context, R.string.gdpr_network_applovin, R.string.gdpr_network_applovin_link, R.string.gdpr_type_ads, true, true);
+
+
         FIREBASE_DATABASE = new GDPRNetwork(context, R.string.gdpr_network_firebase, R.string.gdpr_network_firebase_link, R.string.gdpr_type_cloud_database, false, false);
         FIREBASE_CRASH = new GDPRNetwork(context, R.string.gdpr_network_firebase, R.string.gdpr_network_firebase_link, R.string.gdpr_type_crash, false, false);
         FIREBASE_ANALYTICS = new GDPRNetwork(context, R.string.gdpr_network_firebase, R.string.gdpr_network_firebase_link, R.string.gdpr_type_analytics, false, false);

--- a/library/src/main/res/values/service_strings.xml
+++ b/library/src/main/res/values/service_strings.xml
@@ -11,4 +11,36 @@
     <string name="gdpr_network_firebase" translatable="false">Firebase</string>
     <string name="gdpr_network_firebase_link" translatable="false">https://firebase.google.com/support/privacy/</string>
 
+    <string name="gdpr_network_aerserv" translatable="false">AerServ</string>
+    <string name="gdpr_network_aerserv_link" translatable="false">https://support.aerserv.com/hc/en-us/articles/360000781223</string>
+
+    <string name="gdpr_network_inmobi" translatable="false">InMobi</string>
+    <string name="gdpr_network_inmobi_link" translatable="false">https://support.inmobi.com/monetize/integration/gdpr-guide-for-publishers/</string>
+
+    <string name="gdpr_network_mopub" translatable="false">Mopub</string>
+    <string name="gdpr_network_mopub_link" translatable="false">https://www.mopub.com/resources/gdpr-faq/</string>
+
+    <string name="gdpr_network_vungle" translatable="false">Vungle</string>
+    <string name="gdpr_network_vungle_link" translatable="false">https://vungle.com/gdpr-faq/</string>
+
+    <string name="gdpr_network_adcolony" translatable="false">AdColony</string>
+    <string name="gdpr_network_adcolony_link" translatable="false">https://www.adcolony.com/gdpr/</string>
+
+    <string name="gdpr_network_unity" translatable="false">Unity</string>
+    <string name="gdpr_network_unity_link" translatable="false">https://unity3d.com/legal/gdpr</string>
+
+    <string name="gdpr_network_applovin" translatable="false">AppLovin</string>
+    <string name="gdpr_network_applovin_link" translatable="false">https://www.applovin.com/gdprfaqs/</string>
+
+
+
+
+
+
+
+
+
+
+
+
 </resources>

--- a/library/src/main/res/values/service_strings.xml
+++ b/library/src/main/res/values/service_strings.xml
@@ -12,25 +12,25 @@
     <string name="gdpr_network_firebase_link" translatable="false">https://firebase.google.com/support/privacy/</string>
 
     <string name="gdpr_network_aerserv" translatable="false">AerServ</string>
-    <string name="gdpr_network_aerserv_link" translatable="false">https://support.aerserv.com/hc/en-us/articles/360000781223</string>
+    <string name="gdpr_network_aerserv_link" translatable="false">https://www.aerserv.com/privacy-policy/</string>
 
     <string name="gdpr_network_inmobi" translatable="false">InMobi</string>
-    <string name="gdpr_network_inmobi_link" translatable="false">https://support.inmobi.com/monetize/integration/gdpr-guide-for-publishers/</string>
+    <string name="gdpr_network_inmobi_link" translatable="false">https://www.inmobi.com/privacy-policy-for-eea/</string>
 
     <string name="gdpr_network_mopub" translatable="false">Mopub</string>
-    <string name="gdpr_network_mopub_link" translatable="false">https://www.mopub.com/resources/gdpr-faq/</string>
+    <string name="gdpr_network_mopub_link" translatable="false">https://www.mopub.com/legal/privacy/</string>
 
     <string name="gdpr_network_vungle" translatable="false">Vungle</string>
-    <string name="gdpr_network_vungle_link" translatable="false">https://vungle.com/gdpr-faq/</string>
+    <string name="gdpr_network_vungle_link" translatable="false">https://vungle.com/privacy/</string>
 
     <string name="gdpr_network_adcolony" translatable="false">AdColony</string>
-    <string name="gdpr_network_adcolony_link" translatable="false">https://www.adcolony.com/gdpr/</string>
+    <string name="gdpr_network_adcolony_link" translatable="false">https://www.adcolony.com/privacy-policy/</string>
 
     <string name="gdpr_network_unity" translatable="false">Unity</string>
-    <string name="gdpr_network_unity_link" translatable="false">https://unity3d.com/legal/gdpr</string>
+    <string name="gdpr_network_unity_link" translatable="false">https://unity3d.com/legal/privacy-policy</string>
 
     <string name="gdpr_network_applovin" translatable="false">AppLovin</string>
-    <string name="gdpr_network_applovin_link" translatable="false">https://www.applovin.com/gdprfaqs/</string>
+    <string name="gdpr_network_applovin_link" translatable="false">https://www.applovin.com/privacy/</string>
 
 
 


### PR DESCRIPTION
Added AerServ, Inmobi, Mopub, Vungle, AdColony, Unity, AppLovin for starters. 
There's probably more to the list, but wanted to start off small.
The links can be changed, I just looked up the GDPR policy for most of them. 

FYI - might just be me, but I had to disable configuration on demand to test the new strings/build the APK. 
Looks like it impacts everyone who is using the latest Android Studio. :) 

https://stackoverflow.com/questions/49990933/configuration-on-demand-is-not-supported-by-the-current-version-of-the-android-g
