### PR TITLE
Use MaterialComponents theme

### DIFF
--- a/app/src/main/res/layout/activity_setup.xml
+++ b/app/src/main/res/layout/activity_setup.xml
@@ -271,7 +271,7 @@
 
         <Button
             android:id="@+id/btTest"
-            style="@style/Widget.AppCompat.Button.Colored"
+            style="@style/Widget.MaterialComponents.Button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:onClick="onClick"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>

--- a/library/src/main/res/layout-land/gdpr_dialog_bottom.xml
+++ b/library/src/main/res/layout-land/gdpr_dialog_bottom.xml
@@ -14,7 +14,7 @@
 
             <Button
                 android:id="@+id/btDisagree"
-                style="@style/Widget.AppCompat.Button.Borderless"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/gdpr_dialog_disagree_no_thanks"/>
@@ -23,7 +23,7 @@
 
         <Button
             android:id="@+id/btAgree"
-            style="@style/Widget.AppCompat.Button.Colored"
+            style="@style/Widget.MaterialComponents.Button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
@@ -33,7 +33,7 @@
 
     <Button
         android:id="@+id/btNoConsentAtAll"
-        style="@style/Widget.AppCompat.Button.Borderless"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/gdpr_dialog_disagree_no_ads"/>

--- a/library/src/main/res/layout/gdpr_dialog.xml
+++ b/library/src/main/res/layout/gdpr_dialog.xml
@@ -39,7 +39,7 @@
 
                     <TextView
                         android:id="@+id/tvText1"
-                        style="@style/TextAppearance.AppCompat.Small"
+                        style="@style/TextAppearance.MaterialComponents.Body2"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="@dimen/gdpr_big_padding"
@@ -50,7 +50,7 @@
 
                     <TextView
                         android:id="@+id/tvText2"
-                        style="@style/TextAppearance.AppCompat.Small"
+                        style="@style/TextAppearance.MaterialComponents.Body2"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="@string/gdpr_dialog_text2_singular"
@@ -58,7 +58,7 @@
 
                     <TextView
                         android:id="@+id/tvQuestion"
-                        style="@style/TextAppearance.AppCompat.Small"
+                        style="@style/TextAppearance.MaterialComponents.Body2"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="@dimen/gdpr_big_padding"
@@ -70,7 +70,7 @@
 
                     <TextView
                         android:id="@+id/tvText3"
-                        style="@style/TextAppearance.AppCompat.Small"
+                        style="@style/TextAppearance.MaterialComponents.Body2"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="@string/gdpr_dialog_text3"
@@ -104,7 +104,7 @@
 
             <TextView
                 android:id="@+id/tvServiceInfo1"
-                style="@style/TextAppearance.AppCompat.Small"
+                style="@style/TextAppearance.MaterialComponents.Body2"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/gdpr_dialog_text_info1"/>
@@ -119,7 +119,7 @@
 
                 <TextView
                     android:id="@+id/tvServiceInfo2"
-                    style="@style/TextAppearance.AppCompat.Small"
+                    style="@style/TextAppearance.MaterialComponents.Body2"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text=""/>
@@ -128,7 +128,7 @@
 
             <TextView
                 android:id="@+id/tvServiceInfo3"
-                style="@style/TextAppearance.AppCompat.Small"
+                style="@style/TextAppearance.MaterialComponents.Body2"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/gdpr_small_padding"
@@ -136,7 +136,7 @@
 
             <Button
                 android:id="@+id/btBack"
-                style="@style/Widget.AppCompat.Button.Colored"
+                style="@style/Widget.MaterialComponents.Button"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/gdpr_dialog_back"/>
@@ -153,7 +153,7 @@
 
             <TextView
                 android:id="@+id/tvNonPersonalisedInfo1"
-                style="@style/TextAppearance.AppCompat.Small"
+                style="@style/TextAppearance.MaterialComponents.Body2"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/gdpr_small_padding"
@@ -161,7 +161,7 @@
 
             <Button
                 android:id="@+id/btAgreeNonPersonalised"
-                style="@style/Widget.AppCompat.Button.Colored"
+                style="@style/Widget.MaterialComponents.Button"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/gdpr_dialog_agree"/>

--- a/library/src/main/res/layout/gdpr_dialog_bottom.xml
+++ b/library/src/main/res/layout/gdpr_dialog_bottom.xml
@@ -3,21 +3,21 @@
 
     <Button
         android:id="@+id/btAgree"
-        style="@style/Widget.AppCompat.Button.Colored"
+        style="@style/Widget.MaterialComponents.Button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/gdpr_dialog_agree"/>
 
     <Button
         android:id="@+id/btDisagree"
-        style="@style/Widget.AppCompat.Button.Borderless"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/gdpr_dialog_disagree_no_thanks"/>
 
     <Button
         android:id="@+id/btNoConsentAtAll"
-        style="@style/Widget.AppCompat.Button.Borderless"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/gdpr_dialog_disagree_no_ads"/>

--- a/library/src/main/res/layout/gdpr_dialog_bottom.xml
+++ b/library/src/main/res/layout/gdpr_dialog_bottom.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/btAgree"
         style="@style/Widget.MaterialComponents.Button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/gdpr_dialog_agree"/>
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/btDisagree"
-        style="@style/Widget.MaterialComponents.Button.TextButton"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/gdpr_dialog_disagree_no_thanks"/>
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/btNoConsentAtAll"
-        style="@style/Widget.MaterialComponents.Button.TextButton"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/gdpr_dialog_disagree_no_ads"/>


### PR DESCRIPTION
close #81 

I've switched all theme/style inside the library to MaterialComponents.

Here's the screenshot of the demo app.
![screenshot_1551524565](https://user-images.githubusercontent.com/654889/53681006-5d9afa00-3d26-11e9-9253-fcc5a5e9b768.png)

However, if AppTheme is extended from AppCompat theme, it looks like this

![screenshot_1551524839](https://user-images.githubusercontent.com/654889/53681037-d7cb7e80-3d26-11e9-98fe-ce34e90a8106.png)

So how should we handle this?

My idea is below two:

- specify default dialog theme inside `DialogSetup`(change `DialogSetup.mCustomeTheme`'s default value to `Theme.MaterialComponents.Light.Dialog.Alert`?) 
- Leave it as it is, user should explicitly pass a custom dialog theme which is extended from MaterialComponents theme, if they want to use the lib with AppCompat theme
